### PR TITLE
change wildcard regex to allow for dots in filename

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -118,15 +118,15 @@ function initialize (config) {
   // Router for / and /index with or without search parameter
   if (config.googleoauth === true) {
     router.get('/:var(index)?', oauth2.required, route_search, route_home);
-    router.get(/^([^.]*)/, oauth2.required, route_wildcard);
+    router.get(/^(.*)/, oauth2.required, route_wildcard);
   } else if (config.authentication_for_read === true) {
     router.get('/sitemap.xml', authenticate, route_sitemap);
     router.get('/:var(index)?', authenticate, route_search, route_home);
-    router.get(/^([^.]*)/, authenticate, route_wildcard);
+    router.get(/^(.*)/, authenticate, route_wildcard);
   } else {
     router.get('/sitemap.xml', route_sitemap);
     router.get('/:var(index)?', route_search, route_home);
-    router.get(/^([^.]*)/, route_wildcard);
+    router.get(/^(.*)/, route_wildcard);
   }
 
   // Handle Errors


### PR DESCRIPTION
Implementing a fix for #317 - error when md file name contains dot.

I'm not sure if there was a reason dots were excluded from paths to match the wildcard - I was unable to perform a directory traversal but maybe there was another reason? If so let me know and I'll abandon this!
But with some local testing it seems to be behaving fine and files with a dot in the name now load