### PR TITLE
Fix support for ignored directories

### DIFF
--- a/app/core/contents.js
+++ b/app/core/contents.js
@@ -38,7 +38,13 @@ async function handler (activePageSlug, config) {
     } else if (result && result.is_directory === false) {
       const dirSlug = path.dirname(result.slug);
       const parent = _.find(filesProcessed, item => item.slug === dirSlug);
-      parent.files.push(result);
+      if (parent) {
+        parent.files.push(result);
+      } else {
+        if (config.debug) {
+          console.log('Content ignored', result.slug);
+        }
+      }
     }
   }
 
@@ -66,7 +72,11 @@ async function processFile (config, activePageSlug, contentDir, filePath) {
 
     const ignoreExists = await fs.lstat(ignoreFile).then(stat => stat.isFile(), () => {});
     if (ignoreExists) {
-      return true;
+      if (config.debug) {
+        console.log('Directory ignored', contentDir + shortPath);
+      }
+
+      return null;
     }
 
     let dirMetadata = {};

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start_win": "set DEBUG=raneto&&node example/server.js",
     "test": "npm run lint && mocha --reporter spec test/*.js",
     "gulp": "gulp",
-    "lint": "./node_modules/.bin/eslint bin/* app/**/*.js example/**/*.js test/*.js gulpfile.js",
+    "lint": "eslint bin/* app/**/*.js example/**/*.js test/*.js gulpfile.js",
     "postinstall": "gulp default"
   },
   "engines": {

--- a/test/content/sub/hidden/not_on_menu.md
+++ b/test/content/sub/hidden/not_on_menu.md
@@ -1,0 +1,1 @@
+Files in this directory are not listed in the navigation menu, but still can be loaded.


### PR DESCRIPTION
There was old support for ignoring directories in listing: https://github.com/gilbitron/Raneto-Core/commit/d74a0e1b7ef4688b965737807946f3585e6253ac
but it was crashing when attempting to use it.

This PR adds it to test content and fixes the crash.