### PR TITLE
ShowOnMenu can now be used to show and hide pages on the site menu

### DIFF
--- a/app/core/contents.js
+++ b/app/core/contents.js
@@ -19,6 +19,7 @@ async function handler(activePageSlug, config) {
     slug: '.',
     title: '',
     show_on_home: true,
+    show_on_menu: true,
     is_index: true,
     active: baseSlug === '',
     class: 'category-index',
@@ -115,6 +116,9 @@ async function processFile(config, activePageSlug, contentDir, filePath) {
         : config.show_on_home_default,
       is_index: false,
       is_directory: true,
+      show_on_menu: dirMetadata.show_on_menu
+        ? dirMetadata.show_on_menu === 'true'
+        : config.show_on_menu_default,
       active: activePageSlug.startsWith(`/${fileSlug}`),
       class: `category-${contentProcessors.cleanString(fileSlug)}`,
       sort: dirMetadata.sort || sort,
@@ -148,6 +152,9 @@ async function processFile(config, activePageSlug, contentDir, filePath) {
           ? meta.show_on_home === 'true'
           : config.show_on_home_default,
         is_directory: false,
+        show_on_menu: meta.show_on_menu
+          ? meta.show_on_menu === 'true'
+          : config.show_on_menu_default,
         active: activePageSlug.trim() === `/${slug}`,
         sort: pageSort,
       };

--- a/app/routes/wildcard.route.js
+++ b/app/routes/wildcard.route.js
@@ -1,5 +1,6 @@
 // Modules
 var path = require('path');
+var _ = require('underscore');
 var fs = require('fs-extra');
 const { marked } = require('marked');
 var toc = require('markdown-toc');
@@ -98,7 +99,17 @@ function route_wildcard(config) {
 
       var pageList = remove_image_content_directory(
         config,
-        await contentsHandler(slug, config)
+        _.chain(await contentsHandler(slug, config))
+          .filter((page) => page.show_on_menu)
+          .map((page) => {
+            page.files = _.filter(page.files, (file) => {
+              console.log(file)
+              return file.show_on_menu
+            });
+            return page;
+          })
+          .value()
+
       );
 
       var loggedIn =
@@ -118,9 +129,7 @@ function route_wildcard(config) {
         pages: build_nested_pages(pageList),
         meta,
         content,
-        current_url: `${req.protocol}://${req.get('host')}${
-          config.path_prefix
-        }${req.originalUrl}`,
+        current_url: `${req.protocol}://${req.get('host')}${config.path_prefix}${req.originalUrl}`,
         body_class: `${template}-${contentProcessors.cleanString(slug)}`,
         last_modified: await utils.getLastModified(config, meta, file_path),
         lang: config.lang,

--- a/app/routes/wildcard.route.js
+++ b/app/routes/wildcard.route.js
@@ -103,7 +103,6 @@ function route_wildcard(config) {
           .filter((page) => page.show_on_menu)
           .map((page) => {
             page.files = _.filter(page.files, (file) => {
-              console.log(file)
               return file.show_on_menu
             });
             return page;

--- a/app/routes/wildcard.route.js
+++ b/app/routes/wildcard.route.js
@@ -129,7 +129,9 @@ function route_wildcard(config) {
         pages: build_nested_pages(pageList),
         meta,
         content,
-        current_url: `${req.protocol}://${req.get('host')}${config.path_prefix}${req.originalUrl}`,
+        current_url: `${req.protocol}://${req.get('host')}${
+          config.path_prefix
+        }${req.originalUrl}`,
         body_class: `${template}-${contentProcessors.cleanString(slug)}`,
         last_modified: await utils.getLastModified(config, meta, file_path),
         lang: config.lang,

--- a/config/config.js
+++ b/config/config.js
@@ -12,8 +12,7 @@ var path = require('path');
 var theme_dir = path.join(
   __dirname,
   '..',
-  'node_modules',
-  '@raneto/theme-default'
+  'themes'
 );
 var theme_name = 'dist';
 
@@ -58,6 +57,10 @@ var config = {
   // Controls behavior of home page if meta ShowOnHome is not present. If set to true
   // all categories or files that do not specify ShowOnHome meta property will be shown
   show_on_home_default: true,
+
+  // Controls behavior of the menu if meta ShowOnMenu is not present. If set to true
+  // all categories or files that do not specify ShowOnMenu meta property will be shown
+  show_on_menu_default: true,
 
   // Theme (see top of file)
   theme_dir,

--- a/config/config.js
+++ b/config/config.js
@@ -12,7 +12,8 @@ var path = require('path');
 var theme_dir = path.join(
   __dirname,
   '..',
-  'themes'
+  'node_modules',
+  '@raneto/theme-default'
 );
 var theme_name = 'dist';
 

--- a/content/pages/usage/category-meta.md
+++ b/content/pages/usage/category-meta.md
@@ -6,7 +6,8 @@ You can add a file called meta (with no extension) in the category folder. This 
 
  * Title - This variable will override the title based on the folder name.
  * Sort - This variable will affect the sorting of the categories.
- * ShowOnHome - Optional. If false, categoru won't show on the home page. Default behavior can be changed through `config.show_on_home_default`.
+ * ShowOnHome - Optional. If false, category won't show on the home page. Default behavior can be changed through `config.show_on_home_default`.
+ * ShowOnMenu - Optional. If false, category won't show on the site menu. Default behavior can be changed through `config.show_on_menu_default`.
  * Description - Optional. This variable will provide a variable to be used in the templates, for example in the hompage, to enhance and clarify the content of the category.
 
-Note that `config.show_on_home_default` sets the default behavior for pages too.
+Note that `config.show_on_home_default` and `config.show_on_menu_default` will sets the default behavior for pages too.

--- a/content/pages/usage/page-meta.md
+++ b/content/pages/usage/page-meta.md
@@ -1,7 +1,7 @@
 ---
 Title: Page Meta
 Description: This page describes how the Meta information works.
-Modified: 2016-09-14T11:50:00-0500
+Modified: 2023-09-15T19:00:00-0100
 ---
 
 Each page can contain optional meta data about the page. This is useful when you need the page to have a different
@@ -12,8 +12,9 @@ should be written in [YAML](https://yaml.org/spec/1.2.2/).
  * Description - This variable will give `lunr` a description to search on.
  * Sort - This variable will affect the sorting of the pages inside the category.
  * ShowOnHome - Optional. If false, page won't be listed on the home page. Default behavior can be changed through `config.show_on_home_default`.
+ * ShowOnMenu - Optional. If false, page won't be listed on the site menu. Default behavior can be changed through `config.show_on_menu_default`.
  * Modified - This variable will override the modified date based on the file name.
    * This should be in full ISO 8601 format including Time and Timezone offset.
 
-Before version 0.11.0 these meta blocks could only be HTML comments (/\* \*/).  
+Before version 0.11.0 these meta blocks could only be HTML comments (/\* \*/).
 Starting with version 0.11.0, the meta blocks should be YAML blocks.

--- a/content/pages/what-is-raneto.md
+++ b/content/pages/what-is-raneto.md
@@ -2,6 +2,7 @@
 Title: What is Raneto?
 Sort: 1
 ShowOnHome: true
+ShowOnMenu: false
 ---
 
 Raneto is a Knowledgebase platform for [Node.js](https://nodejs.org/) that uses static

--- a/test/content/hidden-page.md
+++ b/test/content/hidden-page.md
@@ -2,6 +2,7 @@
 Title: Hidden Page
 Sort: 4
 ShowOnHome: false
+ShowOnMenu: false
 */
 
 This page shoulnd't appear on the home page.

--- a/test/content/sub/not_on_home/meta
+++ b/test/content/sub/not_on_home/meta
@@ -1,3 +1,4 @@
 Title: Not on home page
 Sort: 2
 ShowOnHome: false
+ShowOnMenu: false

--- a/test/raneto-core.test.js
+++ b/test/raneto-core.test.js
@@ -18,6 +18,7 @@ const config = {
   page_sort_meta: 'sort',
   category_sort: true,
   show_on_home_default: true,
+  show_on_menu_default: true,
   searchExtraLanguages: ['ru'],
   debug: false,
   content_dir: path.join(__dirname, 'content/'),
@@ -284,7 +285,58 @@ describe('#getPages()', () => {
     );
     expect(result[0]).to.have.property('show_on_home', true);
   });
+
+  it('adds show_on_menu property to directory', async () => {
+    const result = await contentsHandler(null, config);
+    expect(result[0]).to.have.property('show_on_menu', true);
+  });
+
+  it('adds show_on_menu property to files', async () => {
+    const result = await contentsHandler(null, config);
+    expect(result[0].files[0]).to.have.property('show_on_menu', true);
+  });
+
+  it('loads meta show_on_menu value from directory', async () => {
+    const result = await contentsHandler(null, config);
+    expect(result[3]).to.have.property('show_on_menu', false);
+  });
+
+  it('loads meta show_on_menu value from file', async () => {
+    const result = await contentsHandler(null, config);
+    expect(result[0].files[4]).to.have.property('show_on_menu', false);
+  });
+
+  it('applies show_on_menu_default in absence of meta for directories', async () => {
+    const result = await contentsHandler(
+      null,
+      Object.assign(config, {
+        show_on_menu_default: false,
+      })
+    );
+    expect(result[1]).to.have.property('show_on_menu', false);
+  });
+
+  it('applies show_on_menu_default in absence of meta for files', async () => {
+    const result = await contentsHandler(
+      null,
+      Object.assign(config, {
+        show_on_menu_default: false,
+      })
+    );
+    expect(result[1].files[0]).to.have.property('show_on_menu', false);
+  });
+
+  it('category main always shows on menu', async () => {
+    const result = await contentsHandler(
+      null,
+      Object.assign(config, {
+        show_on_menu_default: false,
+      })
+    );
+    expect(result[0]).to.have.property('show_on_menu', true);
+  });
 });
+
 
 describe('#doSearch()', () => {
   it('returns an array of search results', async () => {


### PR DESCRIPTION
Following the example of https://github.com/ryanlelek/Raneto/pull/223/commits from @dgarcia202 I've added a "ShowOnMenu" options, to allow to filter which pages can be present on the menu and which one shouldn't. In this case too, all pages behave following a default setting, and are visible in not set otherwise.

When the page is not visibile in the site menu, it is still active and visible by visiting the url. 

I've also updated the test to include the new feature, using the existing one as a guideline.