### PR TITLE
Added targets for links from table of contents

### DIFF
--- a/app/routes/wildcard.route.js
+++ b/app/routes/wildcard.route.js
@@ -9,6 +9,7 @@ import remove_image_content_directory from '../functions/remove_image_content_di
 import content_processors from '../functions/content_processors.js';
 import contents_handler from '../core/contents.js';
 import utils from '../core/utils.js';
+import { gfmHeadingId } from 'marked-gfm-heading-id';
 
 function route_wildcard(config) {
   return async function (req, res, next) {
@@ -90,6 +91,8 @@ function route_wildcard(config) {
             content = `#### Table of Contents\n${tableOfContents.content}\n\n${content}`;
           }
         }
+
+        marked.use(gfmHeadingId());
 
         // Render Markdown
         marked.use({


### PR DESCRIPTION
I added targets for the links generated in the optional table of contents for each page.

Question: I'm surprised that this feature is not already implemented.  If I missed it, please give me a hint.

Suggestion: You might consider enclosing these added lines inside an if statement:

    if (config.table_of_contents) {  ... }

Thank you much for Raneto.  It's a great piece of code.

Dave